### PR TITLE
Checking initial data to ensure it's an array.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ class SSE extends EventEmitter {
   constructor(initial = []) {
     super();
 
-    this.initial = initial;
+    this.initial = Array.isArray(initial) ? initial : [ initial ]; 
 
     this.init = this.init.bind(this);
   }
@@ -57,7 +57,7 @@ class SSE extends EventEmitter {
    * @param {array} data array containing data to be served on new connections
    */
   updateInit(data) {
-    this.initial = data;
+    this.initial =  Array.isArray(data) ? data : [ data ];
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ class SSE extends EventEmitter {
   constructor(initial = []) {
     super();
 
-    this.initial = Array.isArray(initial) ? initial : [ initial ]; 
+    this.initial = Array.isArray(initial) ? initial : [initial]; 
 
     this.init = this.init.bind(this);
   }
@@ -57,7 +57,7 @@ class SSE extends EventEmitter {
    * @param {array} data array containing data to be served on new connections
    */
   updateInit(data) {
-    this.initial =  Array.isArray(data) ? data : [ data ];
+    this.initial = Array.isArray(data) ? data : [data];
   }
 
   /**


### PR DESCRIPTION
Adding a simple check to make sure `initial` and `data` are arrays. If it is not an array, the value is placed in one so `init` will send messages correctly. 