### PR TITLE
Add options and support for changing initial data behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,14 +31,7 @@ class SSE extends EventEmitter {
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
-    if (this.initial) {
-      let initialSend = '';
-      this.initial.forEach((el, i) => {
-        initialSend += `id: ${id}\ndata: ${JSON.stringify(this.initial[i])}\n\n`;
-        id += 1;
-      });
-      res.write(initialSend);
-    }
+
     this.on('data', data => {
       if (data.id) {
         res.write(`id: ${data.id}\n`);
@@ -51,6 +44,13 @@ class SSE extends EventEmitter {
       }
       res.write(`data: ${JSON.stringify(data.data)}\n\n`);
     });
+
+    if (this.initial) {
+      id = this.initial.reduce((msgId, data) => {
+        this.send(data, null, msgId);
+        return msgId + 1;
+      }, id);
+    }
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -12,11 +12,13 @@ class SSE extends EventEmitter {
   /**
    * Creates a new Server-Sent Event instance
    * @param [array] initial Initial value(s) to be served through SSE
+   * @param [object] options Options for SSE.
    */
-  constructor(initial = []) {
+  constructor(initial = [], options = { isQueue: true }) {
     super();
 
-    this.initial = Array.isArray(initial) ? initial : [initial]; 
+    this.initial = Array.isArray(initial) ? initial : [initial];
+    this.options = options;
 
     this.init = this.init.bind(this);
   }
@@ -46,10 +48,15 @@ class SSE extends EventEmitter {
     });
 
     if (this.initial) {
-      id = this.initial.reduce((msgId, data) => {
-        this.send(data, null, msgId);
-        return msgId + 1;
-      }, id);
+      if(this.options.isQueue) {
+        id = this.initial.reduce((msgId, data) => {
+          this.send(data, null, msgId);
+          return msgId + 1;
+        }, id);
+      } else {
+        this.send(this.initial, null, id);
+        id += 1;
+      }
     }
   }
 


### PR DESCRIPTION
This addresses the question raised in #1.

I've added an `options` object that is passed in when creating a new instance of `SSE`. Currently it accepts one option: `isQueue`. If `isQueue` is true, the initial data will be sent out as individual messages. That is, an initial data array with 5 items would send 5 five messages. 

If `isQueue` is false, the initial message will be send as a single message. An array of 5 items would send one message consisting of a array with the five messages.

I've defaulted `isQueue` to `true` to maintain the current functionality. 

I also replace `forEach` with `reduce` and now use `send` instead of `res.write` for sending messages. This was to consolidate the functionality for sending messages in one function that is used in both places.