### PR TITLE
Proposed feature: automatic queuing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,13 @@ class SSE extends EventEmitter {
    * @param [array] initial Initial value(s) to be served through SSE
    * @param [object] options Options for SSE.
    */
-  constructor(initial = [], options = { isQueue: true }) {
+  constructor(initial = [], options = { isQueue: true, autoQueue: false, queueLength: 10 }) {
     super();
+
+    if(options.autoQueue) {
+      options.isQueue = true;
+      options.queueLength = typeof options.queueLength !== 'undefined' ? options.queueLength : 10;
+    }
 
     this.initial = Array.isArray(initial) ? initial : [initial];
     this.options = options;
@@ -45,16 +50,22 @@ class SSE extends EventEmitter {
         res.write(`event: ${data.event}\n`);
       }
       res.write(`data: ${JSON.stringify(data.data)}\n\n`);
+      if(!data.isInitial && this.options.autoQueue) {
+        this.initial.push(data.data);
+        if(this.options.queueLength > 0 && this.initial.length > this.options.queueLength) {
+          this.initial.splice(0, this.initial.length - this.options.queueLength);
+        }
+      }
     });
 
     if (this.initial) {
       if(this.options.isQueue) {
         id = this.initial.reduce((msgId, data) => {
-          this.send(data, null, msgId);
+          this.send(data, null, msgId, true);
           return msgId + 1;
         }, id);
       } else {
-        this.send(this.initial, null, id);
+        this.send(this.initial, null, id, true);
         id += 1;
       }
     }
@@ -74,8 +85,8 @@ class SSE extends EventEmitter {
    * @param [string] event Event name
    * @param [(string|number)] id Custom event ID
    */
-  send(data, event, id) {
-    this.emit('data', {data, event, id});
+  send(data, event, id, isInitial) {
+    this.emit('data', {data, event, id, isInitial});
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -31,14 +31,7 @@ class SSE extends EventEmitter {
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
-    if (this.initial) {
-      let initialSend = '';
-      this.initial.forEach((el, i) => {
-        initialSend += `id: ${id}\ndata: ${JSON.stringify(this.initial[i])}\n\n`;
-        id += 1;
-      });
-      res.write(initialSend);
-    }
+
     this.on('data', data => {
       if (data.id) {
         res.write(`id: ${data.id}\n`);
@@ -51,6 +44,13 @@ class SSE extends EventEmitter {
       }
       res.write(`data: ${JSON.stringify(data.data)}\n\n`);
     });
+
+    if (this.initial) {
+      id = this.initial.reduce((msgId, data) => {
+        this.send(data, null, msgId);
+        return msgId + 1;
+      }, id);
+    }
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -12,11 +12,13 @@ class SSE extends EventEmitter {
   /**
    * Creates a new Server-Sent Event instance
    * @param [array] initial Initial value(s) to be served through SSE
+   * @param [object] options Options for SSE.
    */
-  constructor(initial = []) {
+  constructor(initial = [], options = { isQueue: true }) {
     super();
 
-    this.initial = Array.isArray(initial) ? initial : [initial]; 
+    this.initial = Array.isArray(initial) ? initial : [initial];
+    this.options = options;
 
     this.init = this.init.bind(this);
   }
@@ -46,10 +48,15 @@ class SSE extends EventEmitter {
     });
 
     if (this.initial) {
-      id = this.initial.reduce((msgId, data) => {
-        this.send(data, null, msgId);
-        return msgId + 1;
-      }, id);
+      if(this.options.isQueue) {
+        id = this.initial.reduce((msgId, data) => {
+          this.send(data, null, msgId);
+          return msgId + 1;
+        }, id);
+      } else {
+        this.send(this.initial, null, id);
+        id += 1;
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-sse",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An Express middleware for Server-Sent Events (EventSource)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
One of the things that struck me when I was first working with this library is that it treats `initialData` like it's a queue of messages. While it's possible to achieve the functionality manually using just `updateInit`, I wanted to propose adding some functionality that would automatically handle this for users if they wanted it. For existing users, the library should function exactly the same; users will have to manually enable the  autoQueue if they wish to use it. 

I've built off my previous PR. The `options` object now can include two additional arguments: `autoQueue` and `queueLength`. If `autoQueue` is set to true, `initial` will be updated each time a message is sent. It will be pruned back to the correct length on each send, pulling the oldest message out of the queue. Setting `queueLimit` to 0 should allow for an infinite queue but I wouldn't recommend this due to memory limitations. 

If you're not interested in adding this feature, I understand. It was something that I wanted to propose after I worked with the library. 