### PR TITLE
Disable X-Accel-Buffering in response header

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ class SSE extends EventEmitter {
     res.statusCode = 200;
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('X-Accel-Buffering', 'no');
     if (req.httpVersion !== '2.0') {
       res.setHeader('Connection', 'keep-alive');
     }


### PR DESCRIPTION
Nginx buffering can prevent SSE responses from being sent in real-time.  Adding 'X-Accel-Buffering: no;' to the response header will disable buffering for SSE.  See here for more info:  https://serverfault.com/questions/801628/for-server-sent-events-sse-what-nginx-proxy-configuration-is-appropriate