### PR TITLE
fix error when compression is not used

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,9 @@ class SSE extends EventEmitter {
         res.write(`event: ${data.event}\n`);
       }
       res.write(`data: ${JSON.stringify(data.data)}\n\n`);
-      res.flush();
+      if (res.flush) {
+        res.flush();
+      }
     };
 
     const serializeListener = data => {


### PR DESCRIPTION
When you just use express without the compression middleware, there is no res.flush function.