### PR TITLE
Added "no-transform" to "Cache-Control" header

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class SSE extends EventEmitter {
     req.socket.setKeepAlive(true);
     res.statusCode = 200;
     res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Cache-Control', 'no-cache,no-transform');
     res.setHeader('X-Accel-Buffering', 'no');
     if (req.httpVersion !== '2.0') {
       res.setHeader('Connection', 'keep-alive');


### PR DESCRIPTION
Some proxies buffers SSE events to compress the stream. The `no-transform` directive forbidden this bad behavior. More info at:

https://github.com/facebook/create-react-app/issues/1633
https://github.com/vercel/next.js/issues/9965#issuecomment-584319868