### PR TITLE
Remove res.flush

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,6 @@ class SSE extends EventEmitter {
         res.write(`event: ${data.event}\n`);
       }
       res.write(`data: ${JSON.stringify(data.data)}\n\n`);
-      res.flush();
     };
 
     const serializeListener = data => {


### PR DESCRIPTION
Removes res.flush(), causes error  on express 4.17 (TypeError: res.flush is not a function) and occurs on res.write anyway.