### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/dpskvn/express-sse.git"
+    "url": "git+https://github.com/dpskvn/express-sse.git"
   },
   "keywords": [
     "express",


### PR DESCRIPTION
## Summary

- update the package repository URL from the deprecated `git://` protocol to the public HTTPS Git URL
- keep the existing repository target unchanged

## Validation

- `/Users/sw/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); if(p.repository.url !== 'git+https://github.com/dpskvn/express-sse.git') process.exit(1);"`
- `git diff --check`
- `git ls-remote https://github.com/dpskvn/express-sse.git HEAD`
- `node build.js`
- CJS smoke import: `require('./index.js')`
- ESM smoke import: `import('./index.mjs')`
